### PR TITLE
Update install-kiro.sh to generate improved desktop entry files

### DIFF
--- a/install-kiro.sh
+++ b/install-kiro.sh
@@ -504,7 +504,7 @@ Name[ja]=新しい空のウィンドウ
 Name[ko]=새 빈 창
 Name[ru]=Новое пустое окно
 Name[zh_CN]=新建空窗口
-Name[zh_TW]=開新空視窗
+Name[zh_TW]=開新空白視窗
 Exec=$INSTALL_DIR/bin/kiro --new-window %F
 Icon=$ICON_PATH
 "
@@ -512,17 +512,16 @@ Icon=$ICON_PATH
     # Write desktop file
     if [ "$NEED_SUDO" = true ]; then
         echo "$DESKTOP_FILE_CONTENT" | sudo tee "$DESKTOP_DIR/kiro.desktop" > /dev/null
-        sudo chmod +x "$DESKTOP_DIR/kiro.desktop"
+        sudo chmod 644 "$DESKTOP_DIR/kiro.desktop"
     else
         echo "$DESKTOP_FILE_CONTENT" > "$DESKTOP_DIR/kiro.desktop"
-        chmod +x "$DESKTOP_DIR/kiro.desktop"
+        chmod 644 "$DESKTOP_DIR/kiro.desktop"
     fi
 
     # Create URL handler desktop file content
     local URL_HANDLER_CONTENT="[Desktop Entry]
 Name=Kiro - URL Handler
 Comment=Kiro Authentication Handler
-GenericName=Text Editor
 Exec=$INSTALL_DIR/bin/kiro --open-url %U
 Icon=$ICON_PATH
 Type=Application
@@ -534,10 +533,10 @@ MimeType=x-scheme-handler/kiro;
     # Write URL handler desktop file
     if [ "$NEED_SUDO" = true ]; then
         echo "$URL_HANDLER_CONTENT" | sudo tee "$DESKTOP_DIR/kiro-url-handler.desktop" > /dev/null
-        sudo chmod +x "$DESKTOP_DIR/kiro-url-handler.desktop"
+        sudo chmod 644 "$DESKTOP_DIR/kiro-url-handler.desktop"
     else
         echo "$URL_HANDLER_CONTENT" > "$DESKTOP_DIR/kiro-url-handler.desktop"
-        chmod +x "$DESKTOP_DIR/kiro-url-handler.desktop"
+        chmod 644 "$DESKTOP_DIR/kiro-url-handler.desktop"
     fi
     
     # Update desktop database if command exists
@@ -546,6 +545,15 @@ MimeType=x-scheme-handler/kiro;
             sudo update-desktop-database "$DESKTOP_DIR"
         else
             update-desktop-database "$DESKTOP_DIR"
+        fi
+    fi
+    
+    # Register MIME type handler
+    if command -v xdg-mime &> /dev/null; then
+        if [ "$NEED_SUDO" = true ]; then
+            sudo xdg-mime default kiro-url-handler.desktop x-scheme-handler/kiro
+        else
+            xdg-mime default kiro-url-handler.desktop x-scheme-handler/kiro
         fi
     fi
     

--- a/install-kiro.sh
+++ b/install-kiro.sh
@@ -481,14 +481,32 @@ install_kiro() {
     local DESKTOP_FILE_CONTENT="[Desktop Entry]
 Name=Kiro
 Comment=$APP_COMMENT
+GenericName=Text Editor
 Exec=$INSTALL_DIR/bin/kiro %F
 Icon=$ICON_PATH
-Terminal=false
 Type=Application
-Categories=Development;IDE;
-MimeType=text/plain;inode/directory;
+StartupNotify=false
 StartupWMClass=kiro
-StartupNotify=true
+Categories=TextEditor;Development;IDE;
+MimeType=text/plain;inode/directory;
+Actions=new-empty-window;
+Keywords=vscode;
+Terminal=false
+
+[Desktop Action new-empty-window]
+Name=New Empty Window
+Name[cs]=Nové prázdné okno
+Name[de]=Neues leeres Fenster
+Name[es]=Nueva ventana vacía
+Name[fr]=Nouvelle fenêtre vide
+Name[it]=Nuova finestra vuota
+Name[ja]=新しい空のウィンドウ
+Name[ko]=새 빈 창
+Name[ru]=Новое пустое окно
+Name[zh_CN]=新建空窗口
+Name[zh_TW]=開新空視窗
+Exec=$INSTALL_DIR/bin/kiro --new-window %F
+Icon=$ICON_PATH
 "
 
     # Write desktop file
@@ -498,6 +516,28 @@ StartupNotify=true
     else
         echo "$DESKTOP_FILE_CONTENT" > "$DESKTOP_DIR/kiro.desktop"
         chmod +x "$DESKTOP_DIR/kiro.desktop"
+    fi
+
+    # Create URL handler desktop file content
+    local URL_HANDLER_CONTENT="[Desktop Entry]
+Name=Kiro - URL Handler
+Comment=Kiro Authentication Handler
+GenericName=Text Editor
+Exec=$INSTALL_DIR/bin/kiro --open-url %U
+Icon=$ICON_PATH
+Type=Application
+NoDisplay=true
+StartupNotify=true
+MimeType=x-scheme-handler/kiro;
+"
+
+    # Write URL handler desktop file
+    if [ "$NEED_SUDO" = true ]; then
+        echo "$URL_HANDLER_CONTENT" | sudo tee "$DESKTOP_DIR/kiro-url-handler.desktop" > /dev/null
+        sudo chmod +x "$DESKTOP_DIR/kiro-url-handler.desktop"
+    else
+        echo "$URL_HANDLER_CONTENT" > "$DESKTOP_DIR/kiro-url-handler.desktop"
+        chmod +x "$DESKTOP_DIR/kiro-url-handler.desktop"
     fi
     
     # Update desktop database if command exists
@@ -586,14 +626,23 @@ uninstall_kiro() {
         else
             rm "$DESKTOP_DIR/kiro.desktop"
         fi
+    fi
+
+    # Remove URL handler desktop file
+    if [ -f "$DESKTOP_DIR/kiro-url-handler.desktop" ]; then
+        if [ "$NEED_SUDO" = true ]; then
+            sudo rm "$DESKTOP_DIR/kiro-url-handler.desktop"
+        else
+            rm "$DESKTOP_DIR/kiro-url-handler.desktop"
+        fi
+    fi
         
-        # Update desktop database if command exists
-        if command -v update-desktop-database &> /dev/null; then
-            if [ "$NEED_SUDO" = true ]; then
-                sudo update-desktop-database "$DESKTOP_DIR"
-            else
-                update-desktop-database "$DESKTOP_DIR"
-            fi
+    # Update desktop database if command exists
+    if command -v update-desktop-database &> /dev/null; then
+        if [ "$NEED_SUDO" = true ]; then
+            sudo update-desktop-database "$DESKTOP_DIR"
+        else
+            update-desktop-database "$DESKTOP_DIR"
         fi
     fi
 


### PR DESCRIPTION
Enhances desktop integration by generating a more complete `kiro.desktop` with desktop actions and adding a URL handler for authentication flows.

### Changes

- **`kiro.desktop` improvements**
  - Add `GenericName`, `Actions`, `Keywords` fields
  - Add `[Desktop Action new-empty-window]` section with localized names (10 languages)
  - Set `StartupNotify=false`, update `Categories` to include `TextEditor`

- **New `kiro-url-handler.desktop`**
  - Handles `x-scheme-handler/kiro` MIME type for authentication callbacks
  - Hidden from application menus via `NoDisplay=true`

- **Uninstall cleanup**
  - Remove both desktop files on uninstall

All paths dynamically use `$INSTALL_DIR` and `$ICON_PATH` to support both system (`/opt/kiro`) and user (`~/.local/share/kiro`) installations.

### kiro.desktop

```ini
[Desktop Entry]
Name=Kiro
Comment=Kiro - AI-powered development environment
GenericName=Text Editor
Exec=/opt/kiro/bin/kiro %F
Icon=/opt/kiro/resources/app/resources/linux/kiro.png
Type=Application
StartupNotify=false
StartupWMClass=kiro
Categories=TextEditor;Development;IDE;
MimeType=text/plain;inode/directory;
Actions=new-empty-window;
Keywords=vscode;
Terminal=false

[Desktop Action new-empty-window]
Name=New Empty Window
Name[cs]=Nové prázdné okno
Name[de]=Neues leeres Fenster
Name[es]=Nueva ventana vacía
Name[fr]=Nouvelle fenêtre vide
Name[it]=Nuova finestra vuota
Name[ja]=新しい空のウィンドウ
Name[ko]=새 빈 창
Name[ru]=Новое пустое окно
Name[zh_CN]=新建空窗口
Name[zh_TW]=開新空視窗
Exec=/opt/kiro/bin/kiro --new-window %F
Icon=/opt/kiro/resources/app/resources/linux/kiro.png
```

### kiro-url-handler.desktop

```ini
[Desktop Entry]
Name=Kiro - URL Handler
Comment=Kiro Authentication Handler
GenericName=Text Editor
Exec=/opt/kiro/bin/kiro --open-url %U
Icon=/opt/kiro/resources/app/resources/linux/kiro.png
Type=Application
NoDisplay=true
StartupNotify=true
MimeType=x-scheme-handler/kiro;
```
